### PR TITLE
Use dedicated README per NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![GitHub License](https://img.shields.io/github/license/chA0s-Chris/Chaos.Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Chaos.Mongo/blob/main/LICENSE)
 [![NuGet Version](https://img.shields.io/nuget/v/Chaos.Mongo?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Chaos.Mongo?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo)
-[![GitHub last commit](https://img.shields.io/github/last-commit/chA0s-Chris/Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Mongo/commits/)
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/chA0s-Chris/Mongo/ci.yml?style=for-the-badge)]()
+[![GitHub last commit](https://img.shields.io/github/last-commit/chA0s-Chris/Chaos.Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Chaos.Mongo/commits/)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/chA0s-Chris/Chaos.Mongo/ci.yml?style=for-the-badge)]()
 
 A comprehensive MongoDB library for .NET that simplifies working with MongoDB by providing:
 

--- a/docs/event-store.md
+++ b/docs/event-store.md
@@ -1,5 +1,11 @@
 # Chaos.Mongo.EventStore
 
+[![GitHub License](https://img.shields.io/github/license/chA0s-Chris/Chaos.Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Chaos.Mongo/blob/main/LICENSE)
+[![NuGet Version](https://img.shields.io/nuget/v/Chaos.Mongo.EventStore?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo.EventStore)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/Chaos.Mongo.EventStore?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo.EventStore)
+[![GitHub last commit](https://img.shields.io/github/last-commit/chA0s-Chris/Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Mongo/commits/)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/chA0s-Chris/Mongo/ci.yml?style=for-the-badge)]()
+
 Event sourcing capabilities for MongoDB, built on top of `Chaos.Mongo`.
 
 ## Table of Contents

--- a/docs/event-store.md
+++ b/docs/event-store.md
@@ -3,8 +3,8 @@
 [![GitHub License](https://img.shields.io/github/license/chA0s-Chris/Chaos.Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Chaos.Mongo/blob/main/LICENSE)
 [![NuGet Version](https://img.shields.io/nuget/v/Chaos.Mongo.EventStore?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo.EventStore)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Chaos.Mongo.EventStore?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo.EventStore)
-[![GitHub last commit](https://img.shields.io/github/last-commit/chA0s-Chris/Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Mongo/commits/)
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/chA0s-Chris/Mongo/ci.yml?style=for-the-badge)]()
+[![GitHub last commit](https://img.shields.io/github/last-commit/chA0s-Chris/Chaos.Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Chaos.Mongo/commits/)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/chA0s-Chris/Chaos.Mongo/ci.yml?style=for-the-badge)]()
 
 Event sourcing capabilities for MongoDB, built on top of `Chaos.Mongo`.
 

--- a/docs/transactional-outbox.md
+++ b/docs/transactional-outbox.md
@@ -3,8 +3,8 @@
 [![GitHub License](https://img.shields.io/github/license/chA0s-Chris/Chaos.Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Chaos.Mongo/blob/main/LICENSE)
 [![NuGet Version](https://img.shields.io/nuget/v/Chaos.Mongo.Outbox?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo.Outbox)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Chaos.Mongo.Outbox?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo.Outbox)
-[![GitHub last commit](https://img.shields.io/github/last-commit/chA0s-Chris/Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Mongo/commits/)
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/chA0s-Chris/Mongo/ci.yml?style=for-the-badge)]()
+[![GitHub last commit](https://img.shields.io/github/last-commit/chA0s-Chris/Chaos.Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Chaos.Mongo/commits/)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/chA0s-Chris/Chaos.Mongo/ci.yml?style=for-the-badge)]()
 
 Transactional outbox support for MongoDB, built on top of `Chaos.Mongo`.
 

--- a/docs/transactional-outbox.md
+++ b/docs/transactional-outbox.md
@@ -1,5 +1,11 @@
 # Chaos.Mongo.Outbox
 
+[![GitHub License](https://img.shields.io/github/license/chA0s-Chris/Chaos.Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Chaos.Mongo/blob/main/LICENSE)
+[![NuGet Version](https://img.shields.io/nuget/v/Chaos.Mongo.Outbox?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo.Outbox)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/Chaos.Mongo.Outbox?style=for-the-badge)](https://www.nuget.org/packages/Chaos.Mongo.Outbox)
+[![GitHub last commit](https://img.shields.io/github/last-commit/chA0s-Chris/Mongo?style=for-the-badge)](https://github.com/chA0s-Chris/Mongo/commits/)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/chA0s-Chris/Mongo/ci.yml?style=for-the-badge)]()
+
 Transactional outbox support for MongoDB, built on top of `Chaos.Mongo`.
 
 ## Table of Contents

--- a/src/Chaos.Mongo.EventStore/Chaos.Mongo.EventStore.csproj
+++ b/src/Chaos.Mongo.EventStore/Chaos.Mongo.EventStore.csproj
@@ -2,7 +2,11 @@
   <PropertyGroup>
     <PackageId>Chaos.Mongo.EventStore</PackageId>
     <Description>Event sourcing extension for Chaos.Mongo, providing aggregate-based event stores with MongoDB.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="../../docs/event-store.md" Pack="true" Visible="false" PackagePath="README.md" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Chaos.Mongo\Chaos.Mongo.csproj" />
   </ItemGroup>

--- a/src/Chaos.Mongo.Outbox/Chaos.Mongo.Outbox.csproj
+++ b/src/Chaos.Mongo.Outbox/Chaos.Mongo.Outbox.csproj
@@ -2,7 +2,11 @@
   <PropertyGroup>
     <PackageId>Chaos.Mongo.Outbox</PackageId>
     <Description>Transactional outbox pattern extension for Chaos.Mongo, providing reliable at-least-once message delivery with MongoDB.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="../../docs/transactional-outbox.md" Pack="true" Visible="false" PackagePath="README.md" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Chaos.Mongo\Chaos.Mongo.csproj" />
   </ItemGroup>

--- a/src/Chaos.Mongo/Chaos.Mongo.csproj
+++ b/src/Chaos.Mongo/Chaos.Mongo.csproj
@@ -2,7 +2,11 @@
   <PropertyGroup>
     <PackageId>Chaos.Mongo</PackageId>
     <Description>A comprehensive MongoDB library for .NET featuring database migrations, distributed locking, message queues, and database configurators with built-in support for dependency injection.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" Visible="false" PackagePath="" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,7 +10,6 @@
     <Copyright>Copyright © 2025 Christian Flessa</Copyright>
     <PackageProjectUrl>https://github.com/chA0s-Chris/Chaos.Mongo</PackageProjectUrl>
     <PackageTags>MongoDB</PackageTags>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
     <DefineConstants>$(DefineConstants);$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
@@ -22,7 +21,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" Visible="false" PackagePath="" />
     <None Include="../../dist/mongo.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #68

## Changes

### Docs
- `docs/event-store.md` — added badge header (license, NuGet version/downloads for `Chaos.Mongo.EventStore`, last commit, CI status)
- `docs/transactional-outbox.md` — added badge header (license, NuGet version/downloads for `Chaos.Mongo.Outbox`, last commit, CI status)

### Packaging
- `src/Directory.Build.props` — removed shared `PackageReadmeFile` and root `README.md` include
- `src/Chaos.Mongo/Chaos.Mongo.csproj` — now explicitly packages `README.md` (root)
- `src/Chaos.Mongo.EventStore/Chaos.Mongo.EventStore.csproj` — packages `docs/event-store.md` as `README.md`
- `src/Chaos.Mongo.Outbox/Chaos.Mongo.Outbox.csproj` — packages `docs/transactional-outbox.md` as `README.md`

Build: ✅ 0 warnings, 0 errors