### PR TITLE
Add lease extension for held distributed locks

### DIFF
--- a/ai-plans/0110-extend-lock-lease.md
+++ b/ai-plans/0110-extend-lock-lease.md
@@ -10,20 +10,20 @@ Extending decouples the two concerns: callers keep a short initial lease for fas
 
 ## Acceptance Criteria
 
-- [ ] `IMongoLock` exposes a `TryExtendAsync` method that renews the lease of a held lock and updates `ValidUntilUtc`
-- [ ] Calling `TryExtendAsync` without an explicit lease duration renews for the duration the lock was originally acquired with
-- [ ] Extension is refused, without modifying the stored lock document, when the lease has already expired, when the document is held by a different holder, or when the lock has been disposed
-- [ ] A MongoDB failure during extension propagates to the caller, does not mark the lock as lost, and leaves `ValidUntilUtc` unchanged
-- [ ] A refused extension marks the lock as no longer valid, so `IsValid` reports `false` and the existing `EnsureValid()` extension throws afterwards
-- [ ] `MongoLockExtensions` offers a throwing `ExtendAsync` companion that returns the same lock after a successful extension, surfaces a refused extension as an `InvalidOperationException`, and propagates cancellation and MongoDB failures unchanged
-- [ ] The `MongoLock` constructor rejects a null extend delegate, and the constructor, `TryAcquireLockAsync`, and `TryExtendAsync` reject lease durations shorter than one millisecond before invoking a database operation or delegate, with guard-clause coverage matching the existing constructor tests
-- [ ] Concurrent extension and disposal of the same `MongoLock` instance cannot resurrect a released lock or leave `ValidUntilUtc` inconsistent
-- [ ] Releasing a lock deletes only the document carrying that lock's own lease expiry, so disposing a lost or expired lock cannot release a later acquisition made by the same holder
-- [ ] Automated unit and integration tests cover successful renewal, every refusal case, the post-refusal validity state, sub-millisecond lease rejection, and release fencing
-- [ ] A deterministic unit test pauses an in-flight extension while disposal starts, then verifies that disposal uses the resulting expiry and that the disposed lock remains invalid rather than being resurrected
-- [ ] Concurrent real-MongoDB tests using a shared frozen `TimeProvider` verify both expiry-boundary outcomes: before expiry, extension succeeds, acquisition returns `null`, and the document contains the extended lease; at or after expiry, extension returns `false`, acquisition succeeds, and the document contains the new holder and expiry
-- [ ] `docs/distributed-locking.md` documents extension, states that an expired lock cannot be renewed, and explains that extension narrows but does not close the window in which a stalled holder overlaps a new one — including clock skew between instances as a cause, since expiry is evaluated against client clocks
-- [ ] The pull request carries a `breaking` label so release-drafter files the constructor and interface changes under "Breaking Changes" — satisfied at pull-request creation, not during implementation
+- [x] `IMongoLock` exposes a `TryExtendAsync` method that renews the lease of a held lock and updates `ValidUntilUtc`
+- [x] Calling `TryExtendAsync` without an explicit lease duration renews for the duration the lock was originally acquired with
+- [x] Extension is refused, without modifying the stored lock document, when the lease has already expired, when the document is held by a different holder, or when the lock has been disposed
+- [x] A MongoDB failure during extension propagates to the caller, does not mark the lock as lost, and leaves `ValidUntilUtc` unchanged
+- [x] A refused extension marks the lock as no longer valid, so `IsValid` reports `false` and the existing `EnsureValid()` extension throws afterwards
+- [x] `MongoLockExtensions` offers a throwing `ExtendAsync` companion that returns the same lock after a successful extension, surfaces a refused extension as an `InvalidOperationException`, and propagates cancellation and MongoDB failures unchanged
+- [x] The `MongoLock` constructor rejects a null extend delegate, and the constructor, `TryAcquireLockAsync`, and `TryExtendAsync` reject lease durations shorter than one millisecond before invoking a database operation or delegate, with guard-clause coverage matching the existing constructor tests
+- [x] Concurrent extension and disposal of the same `MongoLock` instance cannot resurrect a released lock or leave `ValidUntilUtc` inconsistent
+- [x] Releasing a lock deletes only the document carrying that lock's own lease expiry, so disposing a lost or expired lock cannot release a later acquisition made by the same holder
+- [x] Automated unit and integration tests cover successful renewal, every refusal case, the post-refusal validity state, sub-millisecond lease rejection, and release fencing
+- [x] A deterministic unit test pauses an in-flight extension while disposal starts, then verifies that disposal uses the resulting expiry and that the disposed lock remains invalid rather than being resurrected
+- [x] Concurrent real-MongoDB tests using a shared frozen `TimeProvider` verify both expiry-boundary outcomes: before expiry, extension succeeds, acquisition returns `null`, and the document contains the extended lease; at or after expiry, extension returns `false`, acquisition succeeds, and the document contains the new holder and expiry
+- [x] `docs/distributed-locking.md` documents extension, states that an expired lock cannot be renewed, and explains that extension narrows but does not close the window in which a stalled holder overlaps a new one — including clock skew between instances as a cause, since expiry is evaluated against client clocks
+- [x] The pull request carries a `breaking` label so release-drafter files the constructor and interface changes under "Breaking Changes" — satisfied at pull-request creation, not during implementation
 
 ## Technical Details
 
@@ -31,15 +31,19 @@ Extending decouples the two concerns: callers keep a short initial lease for fas
 
 Extension renews **from the current time**, not from the existing `ValidUntilUtc`. Accumulating onto the previous expiry would let an eager caller push expiry arbitrarily far into the future, reintroducing the long-lease problem this feature exists to solve.
 
-An expired lock is **not** extendable. The atomic update in `MongoHelper` mirrors the take-or-steal filter already used by `TryAcquireLockAsync`, with the liveness condition inverted:
+An expired lock is **not** extendable. The atomic update in `MongoHelper` mirrors the take-or-steal filter already used by `TryAcquireLockAsync`, with the liveness condition inverted and the same expiry fence the release path uses:
 
 ```text
-Id == lockName && Holder == holderId && LeaseUntilUtc > now
+Id == lockName && Holder == holderId && LeaseUntilUtc == <this lock's expiry> && LeaseUntilUtc > now
 ```
 
 The `LeaseUntilUtc > now` clause is the load-bearing part. Without it, a holder whose lease lapsed — but whose document nobody has stolen yet — could silently resurrect the lock while another instance is about to claim it. Failing closed is the only defensible default for a mutex: the caller learns it lost the lock and must abort or acquire again from scratch.
 
+The `LeaseUntilUtc == <this lock's expiry>` clause carries the fencing rule below into extension. Two processes sharing a configured `MongoOptions.HolderId` write the same `Holder` value, so without it a stale instance whose lease was re-acquired by its own holder would extend — and believe it owned — the successor's lock. Extension therefore fences on the same stored expiry that release does, and the extend delegate takes that expiry as a parameter.
+
 Exceptions from the underlying MongoDB operation propagate to the caller and leave the lock's state untouched. `false` is reserved for a definitive loss of the lock, so callers can distinguish a transient failure worth retrying from a lost lock that must abort the work. This distinction is the contract renewal loops depend on, and it matters precisely because automatic renewal is out of scope here.
+
+The expiry fence bounds how far that distinction reaches. A failure that reached the server before the response was lost leaves the instance's cached expiry stale, so the retry the caller was invited to make matches nothing and returns `false` — a refusal that is definitive for the instance but not proof another holder took over. Callers that need the lock must acquire again rather than infer ownership from the refusal. Closing the gap would mean reading the stored document back on refusal and comparing holders, which trades a mutex's fail-closed default for an extra round trip on every lost renewal; it is deliberately out of scope alongside automatic renewal.
 
 Lock expiry is evaluated against the client's `TimeProvider` rather than the server clock, inherited from the existing acquisition path. Clock skew between instances therefore widens the window in which two holders can believe they hold the lock.
 
@@ -47,7 +51,7 @@ Lease durations shorter than one millisecond are rejected because MongoDB stores
 
 ### Components
 
-`MongoHelper` gains an `internal` extend operation alongside `ReleaseLockAsync`, performing a `FindOneAndUpdate` with the filter above and returning the new expiry, or `null` when the filter matched nothing. `TryAcquireLockAsync` passes it to the constructed `MongoLock` together with the lease duration it used. `ReleaseLockAsync` takes the lock's current expiry as an additional filter value, per the fencing rule below.
+`MongoHelper` gains an `internal` extend operation alongside `ReleaseLockAsync`, performing a `FindOneAndUpdate` with the filter above — taking the lock instance's current expiry as a filter value the way `ReleaseLockAsync` does — and returning the new expiry, or `null` when the filter matched nothing. `TryAcquireLockAsync` passes it to the constructed `MongoLock` together with the lease duration it used. `ReleaseLockAsync` takes the lock's current expiry as an additional filter value, per the fencing rule below.
 
 Both acquisition and extension must hand `MongoLock` the expiry **the server returned**, not the locally computed one. MongoDB stores `DateTime` at millisecond precision, so only the stored value can be matched by an equality filter; `TryAcquireLockAsync` currently constructs the lock from its local `leaseUntil` and must use the returned document's `LeaseUntilUtc` instead.
 
@@ -64,7 +68,7 @@ public MongoLock(String id,
                  TimeSpan leaseTime,
                  TimeProvider timeProvider,
                  Func<DateTime, Task> releaseAction,
-                 Func<TimeSpan, CancellationToken, Task<DateTime?>> extendAction)
+                 Func<DateTime, TimeSpan, CancellationToken, Task<DateTime?>> extendAction)
 
 Task<Boolean> IMongoLock.TryExtendAsync(TimeSpan? leaseTime = null,
                                         CancellationToken cancellationToken = default);

--- a/ai-plans/0110-extend-lock-lease.md
+++ b/ai-plans/0110-extend-lock-lease.md
@@ -1,0 +1,105 @@
+# 0110 — Extend the Lease of a Held Distributed Lock
+
+> Issue: [#110](https://github.com/chA0s-Chris/Chaos.Mongo/issues/110)
+
+## Rationale
+
+A lock's lease is fixed when it is acquired, so a long-running holder can lose exclusivity while it is still working. Raising the lease at acquisition is not an acceptable answer, because the lease also bounds how long the lock stays unclaimable after a holder crashes — a longer lease buys safety margin for slow work at the cost of slow recovery.
+
+Extending decouples the two concerns: callers keep a short initial lease for fast crash recovery and renew it while work is still in progress. This plan adds the renewal primitive only. Automatic renewal is deliberately out of scope; it raises separate questions about renewal intervals and how many transient failures to tolerate before abandoning the protected work, and should be revisited once the primitive has real usage.
+
+## Acceptance Criteria
+
+- [ ] `IMongoLock` exposes a `TryExtendAsync` method that renews the lease of a held lock and updates `ValidUntilUtc`
+- [ ] Calling `TryExtendAsync` without an explicit lease duration renews for the duration the lock was originally acquired with
+- [ ] Extension is refused, without modifying the stored lock document, when the lease has already expired, when the document is held by a different holder, or when the lock has been disposed
+- [ ] A MongoDB failure during extension propagates to the caller, does not mark the lock as lost, and leaves `ValidUntilUtc` unchanged
+- [ ] A refused extension marks the lock as no longer valid, so `IsValid` reports `false` and the existing `EnsureValid()` extension throws afterwards
+- [ ] `MongoLockExtensions` offers a throwing `ExtendAsync` companion that returns the same lock after a successful extension, surfaces a refused extension as an `InvalidOperationException`, and propagates cancellation and MongoDB failures unchanged
+- [ ] The `MongoLock` constructor rejects a null extend delegate, and the constructor, `TryAcquireLockAsync`, and `TryExtendAsync` reject lease durations shorter than one millisecond before invoking a database operation or delegate, with guard-clause coverage matching the existing constructor tests
+- [ ] Concurrent extension and disposal of the same `MongoLock` instance cannot resurrect a released lock or leave `ValidUntilUtc` inconsistent
+- [ ] Releasing a lock deletes only the document carrying that lock's own lease expiry, so disposing a lost or expired lock cannot release a later acquisition made by the same holder
+- [ ] Automated unit and integration tests cover successful renewal, every refusal case, the post-refusal validity state, sub-millisecond lease rejection, and release fencing
+- [ ] A deterministic unit test pauses an in-flight extension while disposal starts, then verifies that disposal uses the resulting expiry and that the disposed lock remains invalid rather than being resurrected
+- [ ] Concurrent real-MongoDB tests using a shared frozen `TimeProvider` verify both expiry-boundary outcomes: before expiry, extension succeeds, acquisition returns `null`, and the document contains the extended lease; at or after expiry, extension returns `false`, acquisition succeeds, and the document contains the new holder and expiry
+- [ ] `docs/distributed-locking.md` documents extension, states that an expired lock cannot be renewed, and explains that extension narrows but does not close the window in which a stalled holder overlaps a new one — including clock skew between instances as a cause, since expiry is evaluated against client clocks
+- [ ] The pull request carries a `breaking` label so release-drafter files the constructor and interface changes under "Breaking Changes" — satisfied at pull-request creation, not during implementation
+
+## Technical Details
+
+### Renewal semantics
+
+Extension renews **from the current time**, not from the existing `ValidUntilUtc`. Accumulating onto the previous expiry would let an eager caller push expiry arbitrarily far into the future, reintroducing the long-lease problem this feature exists to solve.
+
+An expired lock is **not** extendable. The atomic update in `MongoHelper` mirrors the take-or-steal filter already used by `TryAcquireLockAsync`, with the liveness condition inverted:
+
+```text
+Id == lockName && Holder == holderId && LeaseUntilUtc > now
+```
+
+The `LeaseUntilUtc > now` clause is the load-bearing part. Without it, a holder whose lease lapsed — but whose document nobody has stolen yet — could silently resurrect the lock while another instance is about to claim it. Failing closed is the only defensible default for a mutex: the caller learns it lost the lock and must abort or acquire again from scratch.
+
+Exceptions from the underlying MongoDB operation propagate to the caller and leave the lock's state untouched. `false` is reserved for a definitive loss of the lock, so callers can distinguish a transient failure worth retrying from a lost lock that must abort the work. This distinction is the contract renewal loops depend on, and it matters precisely because automatic renewal is out of scope here.
+
+Lock expiry is evaluated against the client's `TimeProvider` rather than the server clock, inherited from the existing acquisition path. Clock skew between instances therefore widens the window in which two holders can believe they hold the lock.
+
+Lease durations shorter than one millisecond are rejected because MongoDB stores `DateTime` at millisecond precision. `TryAcquireLockAsync` validates before issuing any database operation, while the `MongoLock` constructor and `TryExtendAsync` validate before invoking their delegates. With a minimum one-millisecond lease, an acquisition that matches an expired stored lease necessarily writes an expiry at least one stored millisecond later, preserving the expiry-based release fence.
+
+### Components
+
+`MongoHelper` gains an `internal` extend operation alongside `ReleaseLockAsync`, performing a `FindOneAndUpdate` with the filter above and returning the new expiry, or `null` when the filter matched nothing. `TryAcquireLockAsync` passes it to the constructed `MongoLock` together with the lease duration it used. `ReleaseLockAsync` takes the lock's current expiry as an additional filter value, per the fencing rule below.
+
+Both acquisition and extension must hand `MongoLock` the expiry **the server returned**, not the locally computed one. MongoDB stores `DateTime` at millisecond precision, so only the stored value can be matched by an equality filter; `TryAcquireLockAsync` currently constructs the lock from its local `leaseUntil` and must use the returned document's `LeaseUntilUtc` instead.
+
+`MongoLock` takes the extend delegate and the original lease duration as **required** constructor parameters. This breaks the existing public constructor's source and binary compatibility, which is acceptable at 0.x; it is preferred over an optional parameter or a second overload because it makes a `MongoLock` that cannot be extended unrepresentable.
+
+Adding `TryExtendAsync` to `IMongoLock` is a second breaking change: external implementers, including hand-written test doubles, no longer satisfy the interface. This is accepted rather than softened with a default interface implementation, which would hand implementers a lock that silently cannot be extended — the same unrepresentable state the constructor decision rules out.
+
+Both breaks are communicated through the release notes, which are generated by release-drafter rather than edited by hand. The `breaking` label must be applied to the pull request; `.github/release-drafter.yml` already maps it to the "💥 Breaking Changes" category, and without it the change would be drafted as an ordinary feature.
+
+```csharp
+// Exact signatures.
+public MongoLock(String id,
+                 DateTime validUntilUtc,
+                 TimeSpan leaseTime,
+                 TimeProvider timeProvider,
+                 Func<DateTime, Task> releaseAction,
+                 Func<TimeSpan, CancellationToken, Task<DateTime?>> extendAction)
+
+Task<Boolean> IMongoLock.TryExtendAsync(TimeSpan? leaseTime = null,
+                                        CancellationToken cancellationToken = default);
+
+public static Task<IMongoLock> ExtendAsync(this IMongoLock mongoLock,
+                                           TimeSpan? leaseTime = null,
+                                           CancellationToken cancellationToken = default);
+```
+
+`ValidUntilUtc` becomes settable privately on `MongoLock`; the interface member stays read-only, so consumers are unaffected.
+
+`ExtendAsync` calls `TryExtendAsync` and returns the same lock instance on success. It rejects a null receiver, converts only a definitive `false` result into `InvalidOperationException`, and lets cancellation and MongoDB exceptions propagate unchanged.
+
+### State and thread safety
+
+A refused extension is terminal for the instance: record it in a lost flag that `IsValid` honours alongside the existing disposed flag.
+
+Disposal needs more than the current holder filter. `MongoHelper` resolves one holder id per instance, so every lock it hands out carries the same `Holder` value and `ReleaseLockAsync` cannot distinguish a stale lock from a later re-acquisition of the same name — disposing a lost or expired lock would delete the document its successor owns, silently freeing a lock the caller believes it holds. Release must therefore also match the lease expiry the lock instance holds:
+
+```text
+Id == lockName && Holder == holderId && LeaseUntilUtc == <this lock's expiry>
+```
+
+Every later acquisition writes an expiry distinct from the expired value it matched, so the stored value acts as an acquisition fence without adding a document field. Extensions do not need to produce a distinct value on every call; they update the same lock instance's current expiry. This is preferred over a local "skip the release when lost or expired" check because it is evaluated atomically on the server, and because it also covers two processes sharing a configured `MongoOptions.HolderId` — something no local check can see.
+
+`MongoLock` must be safe for concurrent use. The intended usage — renewing from a timer while the protected work runs on another thread — makes concurrency inherent rather than exceptional, so the mutable state (disposed flag, lost flag, `ValidUntilUtc`) has to be guarded, and disposal must not race with an in-flight extension in a way that resurrects a released lock. Disposal reads the current expiry under that synchronization and passes it to the `Func<DateTime, Task>` release delegate: when extension wins the synchronization race, disposal observes its returned expiry; when disposal wins, the extension is refused without invoking its delegate. This is a cold path, so favour the simplest construct that makes the invariant obvious over lock-free cleverness.
+
+### Testing
+
+Unit coverage drives the refusal cases through the public API against a fake extend delegate and a controlled `TimeProvider`, following the existing sociable-test approach in `MongoLockTests` and `MongoLockExtensionsTests`. Integration coverage extends `MongoHelperLockIntegrationTests` with the cases that only a real server can prove: a successful renewal observed in the lock document, a refused renewal after another holder has stolen an expired lock, a refused renewal on a lease that expired while unclaimed, and — for the release fencing — disposing a stale lock after the same helper has re-acquired the same name, asserting the successor's document survives.
+
+Two real-MongoDB concurrency tests give both helpers the same frozen `TimeProvider` and start extension by the current holder and acquisition by a competing holder concurrently. With time frozen before expiry, extension must succeed, acquisition must return `null`, and the stored document must contain the extended lease. With time frozen at or after expiry, extension must return `false`, acquisition must succeed, and the stored document must contain the new holder and expiry. These tests verify the complementary filters and atomic document updates under a common clock; they do not claim to close the documented overlap window caused by skewed client clocks.
+
+The constructor change touches all existing `MongoLock` construction sites — 21 across `MongoLockTests` and `MongoLockExtensionsTests`, plus the single production site in `MongoHelper`. The migration is mechanical, but the new parameters need guard-clause coverage matching the existing null-`releaseAction` test.
+
+The extension/disposal concurrency criterion is verified without timing delays by a controllable extend delegate backed by `TaskCompletionSource`: pause extension inside the delegate, start disposal, complete extension, and assert that disposal releases with the returned expiry while the lock remains disposed and invalid. The test complements the synchronization invariant rather than relying on an opportunistic race.
+
+The repository's 95% merged line coverage threshold applies to this change and is a completion condition, not a CI detail to discover afterwards.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@
 | `LockCollectionName`                      | `string`                       | `"_locks"`               | Collection used for distributed locks                          |
 | `MigrationHistoryCollectionName`          | `string`                       | `"_migrations"`          | Collection used for migration history                          |
 | `MigrationsLockName`                      | `string`                       | `"ChaosMongoMigrations"` | Distributed lock used to coordinate migrations                 |
-| `MigrationLockLeaseTime`                  | `TimeSpan`                     | 10 minutes               | Lease duration for the migration lock                          |
+| `MigrationLockLeaseTime`                  | `TimeSpan`                     | 10 minutes               | Lease duration for the migration lock; minimum one millisecond |
 | `HolderId`                                | `string?`                      | Generated identifier     | Identifier for this application instance                       |
 | `ConfigureClientSettings`                 | `Action<MongoClientSettings>?` | `null`                   | Customizes the MongoDB driver client settings                  |
 

--- a/docs/distributed-locking.md
+++ b/docs/distributed-locking.md
@@ -80,6 +80,8 @@ Retrying after such a failure is worthwhile but not guaranteed to succeed: a ren
 
 Extension reduces the chance that long-running work outlives its lease, but it cannot eliminate the overlap window entirely. A holder can stall after its last renewal while another instance acquires the expired lock, then resume. Expiry is evaluated using each instance's client clock, so clock skew can widen this window. Check `IsValid` before exclusivity-sensitive changes and stop the protected work after a refused extension.
 
+Disposing a lock waits for a renewal that is already in flight, so the release uses the expiry that renewal stored instead of a stale one. A slow renewal therefore delays disposal. Cancel the token passed to the renewal when shutdown must not wait for it.
+
 The library does not renew locks automatically. Callers remain responsible for choosing renewal intervals, handling failures, and abandoning work after losing the lock.
 
 ## Recommendations

--- a/docs/distributed-locking.md
+++ b/docs/distributed-locking.md
@@ -52,13 +52,41 @@ public async Task TryProcessJobAsync(CancellationToken cancellationToken = defau
 - A lease allows another instance to recover work if the current holder stops responding.
 - `IMongoLock.IsValid` indicates whether the lock is still within its lease.
 - Lock documents are stored in the collection configured by `MongoOptions.LockCollectionName`.
+- Lease durations shorter than one millisecond are rejected with `ArgumentOutOfRangeException`, because MongoDB stores `DateTime` at millisecond precision. This applies to acquisition, extension, and `MongoOptions.MigrationLockLeaseTime`.
 
-The lease is not an automatic renewal mechanism. Choose a duration that covers the protected work, and do not continue making exclusivity-sensitive changes after the lock is no longer valid.
+## Extend a held lock
+
+Use `TryExtendAsync` to renew a lock before its lease expires. Omitting the duration reuses the duration supplied during acquisition:
+
+```csharp
+if (!await mongoLock.TryExtendAsync(cancellationToken: cancellationToken))
+{
+    logger.LogWarning("The distributed lock was lost");
+    return;
+}
+```
+
+`ExtendAsync` is the throwing companion and returns the same lock after a successful renewal:
+
+```csharp
+await mongoLock.ExtendAsync(
+    leaseTime: TimeSpan.FromMinutes(10),
+    cancellationToken: cancellationToken);
+```
+
+An expired, disposed, or stolen lock cannot be renewed. A refused extension makes that lock instance permanently invalid. MongoDB and cancellation failures propagate without marking the lock as lost, allowing the caller to distinguish an inconclusive operation from a definitive refusal.
+
+Retrying after such a failure is worthwhile but not guaranteed to succeed: a renewal that reached the server before the response was lost leaves the lock instance tracking a stale expiry, and the retry is then refused even though no other holder took over. Treat a refusal following a failed renewal as a signal to stop the protected work and acquire the lock again, not as proof that another instance owns it.
+
+Extension reduces the chance that long-running work outlives its lease, but it cannot eliminate the overlap window entirely. A holder can stall after its last renewal while another instance acquires the expired lock, then resume. Expiry is evaluated using each instance's client clock, so clock skew can widen this window. Check `IsValid` before exclusivity-sensitive changes and stop the protected work after a refused extension.
+
+The library does not renew locks automatically. Callers remain responsible for choosing renewal intervals, handling failures, and abandoning work after losing the lock.
 
 ## Recommendations
 
 - Use descriptive names that identify the protected operation or resource.
 - Set leases long enough for expected work but short enough for useful recovery.
+- Extend long-running leases before they expire, using an application-specific renewal policy.
 - Always use `await using` so normal and exceptional exits release the lock.
 - Pass cancellation tokens to retrying acquisition calls.
 - Decide explicitly how callers should behave when immediate acquisition fails.

--- a/src/Chaos.Mongo/IMongoHelper.cs
+++ b/src/Chaos.Mongo/IMongoHelper.cs
@@ -28,5 +28,6 @@ public interface IMongoHelper : IMongoConnection
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A lock instance if successful, or <c>null</c> if the lock could not be acquired.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="lockName"/> is null or whitespace.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="leaseTime"/> is shorter than one millisecond.</exception>
     Task<IMongoLock?> TryAcquireLockAsync(String lockName, TimeSpan? leaseTime = null, CancellationToken cancellationToken = default);
 }

--- a/src/Chaos.Mongo/IMongoLock.cs
+++ b/src/Chaos.Mongo/IMongoLock.cs
@@ -18,10 +18,28 @@ public interface IMongoLock : IAsyncDisposable
     /// <summary>
     /// Gets a value indicating whether the lock is still valid.
     /// </summary>
+    /// <remarks>
+    /// Reports <see langword="false"/> once the lock has been disposed, its lease has expired, or an extension was refused.
+    /// </remarks>
     Boolean IsValid { get; }
 
     /// <summary>
     /// Gets the UTC date and time when the lock will automatically expire.
     /// </summary>
     DateTime ValidUntilUtc { get; }
+
+    /// <summary>
+    /// Attempts to extend the lease while this instance still owns the lock.
+    /// </summary>
+    /// <remarks>
+    /// A <see langword="false"/> result is final for this instance: the lock counts as lost, <see cref="IsValid"/> reports
+    /// <see langword="false"/> from then on, and further extension attempts are refused without contacting the database.
+    /// Exceptions propagate instead, leaving the lock untouched.
+    /// </remarks>
+    /// <param name="leaseTime">Optional lease duration. Defaults to the duration used to acquire the lock.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns><see langword="true"/> when the lease was extended; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="leaseTime"/> is shorter than one millisecond.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled.</exception>
+    Task<Boolean> TryExtendAsync(TimeSpan? leaseTime = null, CancellationToken cancellationToken = default);
 }

--- a/src/Chaos.Mongo/IMongoLock.cs
+++ b/src/Chaos.Mongo/IMongoLock.cs
@@ -7,6 +7,8 @@ namespace Chaos.Mongo;
 /// </summary>
 /// <remarks>
 /// Dispose the lock to release it. If not disposed, the lock will automatically expire after the lease time.
+/// Disposal waits for an in-flight <see cref="TryExtendAsync"/> call to complete, so the release uses the expiry
+/// that extension stored.
 /// </remarks>
 public interface IMongoLock : IAsyncDisposable
 {
@@ -35,6 +37,8 @@ public interface IMongoLock : IAsyncDisposable
     /// A <see langword="false"/> result is final for this instance: the lock counts as lost, <see cref="IsValid"/> reports
     /// <see langword="false"/> from then on, and further extension attempts are refused without contacting the database.
     /// Exceptions propagate instead, leaving the lock untouched.
+    /// Disposing the lock waits for an extension already in flight, so cancel <paramref name="cancellationToken"/>
+    /// when disposal must not block on a slow renewal.
     /// </remarks>
     /// <param name="leaseTime">Optional lease duration. Defaults to the duration used to acquire the lock.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>

--- a/src/Chaos.Mongo/MongoHelper.cs
+++ b/src/Chaos.Mongo/MongoHelper.cs
@@ -48,20 +48,65 @@ public sealed class MongoHelper : IMongoHelper
     public IMongoDatabase Database { get; }
 
     /// <summary>
+    /// Extends a MongoDB distributed lock if it is still held and unexpired.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="TryAcquireLockAsync"/>, this method does not validate <paramref name="leaseTime"/>:
+    /// <see cref="MongoLock.TryExtendAsync"/> validates it before invoking this operation.
+    /// </remarks>
+    /// <param name="lockName">The name of the lock to extend.</param>
+    /// <param name="holder">The holder ID that currently owns the lock.</param>
+    /// <param name="expectedLeaseUntilUtc">The lease expiry owned by the lock instance.</param>
+    /// <param name="leaseTime">The new lease duration.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The stored lease expiry when extension succeeds; otherwise, <see langword="null"/>.</returns>
+    internal async Task<DateTime?> ExtendLockAsync(String lockName,
+                                                   String holder,
+                                                   DateTime expectedLeaseUntilUtc,
+                                                   TimeSpan leaseTime,
+                                                   CancellationToken cancellationToken = default)
+    {
+        var lockCollection = Database.GetCollection<MongoLockDocument>(_lockCollectionName);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var leaseUntilUtc = now.Add(leaseTime);
+
+        var filter = Builders<MongoLockDocument>.Filter.Eq(x => x.Id, lockName) &
+                     Builders<MongoLockDocument>.Filter.Eq(x => x.Holder, holder) &
+                     Builders<MongoLockDocument>.Filter.Eq(x => x.LeaseUntilUtc, expectedLeaseUntilUtc) &
+                     Builders<MongoLockDocument>.Filter.Gt(x => x.LeaseUntilUtc, now);
+
+        var update = Builders<MongoLockDocument>.Update.Set(x => x.LeaseUntilUtc, leaseUntilUtc);
+        var options = new FindOneAndUpdateOptions<MongoLockDocument>
+        {
+            ReturnDocument = ReturnDocument.After
+        };
+
+        var lockDocument = await lockCollection.FindOneAndUpdateAsync(filter, update, options, cancellationToken);
+        return lockDocument?.LeaseUntilUtc;
+    }
+
+    /// <summary>
     /// Releases a MongoDB distributed lock.
     /// </summary>
     /// <param name="lockName">The name of the lock to release.</param>
     /// <param name="holder">The holder ID that currently owns the lock.</param>
+    /// <param name="leaseUntilUtc">The lease expiry owned by the lock instance.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    internal async Task ReleaseLockAsync(String lockName, String holder)
+    internal async Task ReleaseLockAsync(String lockName, String holder, DateTime leaseUntilUtc)
     {
         var lockCollection = Database.GetCollection<MongoLockDocument>(_lockCollectionName);
 
-        // Only delete the lock if we are still the holder
         var filter = Builders<MongoLockDocument>.Filter.Eq(x => x.Id, lockName) &
-                     Builders<MongoLockDocument>.Filter.Eq(x => x.Holder, holder);
+                     Builders<MongoLockDocument>.Filter.Eq(x => x.Holder, holder) &
+                     Builders<MongoLockDocument>.Filter.Eq(x => x.LeaseUntilUtc, leaseUntilUtc);
 
         await lockCollection.DeleteOneAsync(filter);
+    }
+
+    private static void ValidateLeaseTime(TimeSpan leaseTime)
+    {
+        if (leaseTime < TimeSpan.FromMilliseconds(1))
+            throw new ArgumentOutOfRangeException(nameof(leaseTime), leaseTime, "Lease time must be at least one millisecond.");
     }
 
     /// <inheritdoc/>
@@ -76,6 +121,7 @@ public sealed class MongoHelper : IMongoHelper
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(lockName);
         leaseTime ??= MongoDefaults.LockLeaseTime;
+        ValidateLeaseTime(leaseTime.Value);
 
         var lockCollection = Database.GetCollection<MongoLockDocument>(_lockCollectionName);
         var now = _timeProvider.GetUtcNow().UtcDateTime;
@@ -102,7 +148,15 @@ public sealed class MongoHelper : IMongoHelper
 
             // Verify we successfully acquired the lock
             if (lockDocument?.Holder == _holderId)
-                return new MongoLock(lockName, leaseUntil, _timeProvider, async () => await ReleaseLockAsync(lockName, _holderId));
+            {
+                return new MongoLock(lockName,
+                                     lockDocument.LeaseUntilUtc,
+                                     leaseTime.Value,
+                                     _timeProvider,
+                                     validUntilUtc => ReleaseLockAsync(lockName, _holderId, validUntilUtc),
+                                     (validUntilUtc, extensionLeaseTime, token) =>
+                                         ExtendLockAsync(lockName, _holderId, validUntilUtc, extensionLeaseTime, token));
+            }
 
             return null;
         }

--- a/src/Chaos.Mongo/MongoHelperExtensions.cs
+++ b/src/Chaos.Mongo/MongoHelperExtensions.cs
@@ -24,6 +24,7 @@ public static class MongoHelperExtensions
     /// <param name="cancellationToken">Optional cancellation token to stop lock acquisition attempts.</param>
     /// <returns>A lock instance that must be disposed to release the lock.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="lockName"/> is null or whitespace.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="leaseTime"/> is shorter than one millisecond.</exception>
     /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled.</exception>
     public static async Task<IMongoLock> AcquireLockAsync(this IMongoHelper helper,
                                                           String lockName,

--- a/src/Chaos.Mongo/MongoLock.cs
+++ b/src/Chaos.Mongo/MongoLock.cs
@@ -7,56 +7,157 @@ namespace Chaos.Mongo;
 /// </summary>
 public class MongoLock : IMongoLock
 {
-    private readonly Func<Task> _releaseAction;
+    private readonly Func<DateTime, TimeSpan, CancellationToken, Task<DateTime?>> _extendAction;
+    private readonly TimeSpan _leaseTime;
+
+    // Serializes extension against disposal. Deliberately never disposed: an extension arriving after disposal must
+    // observe the disposed flag and return false, not throw ObjectDisposedException out of WaitAsync.
+    private readonly SemaphoreSlim _operationSemaphore = new(1, 1);
+    private readonly Func<DateTime, Task> _releaseAction;
+    private readonly Object _stateLock = new();
     private readonly TimeProvider _timeProvider;
     private Boolean _disposed;
+    private Boolean _lost;
+    private DateTime _validUntilUtc;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MongoLock"/> class.
     /// </summary>
     /// <param name="id">The unique identifier of the lock.</param>
     /// <param name="validUntilUtc">The UTC date and time when the lock will automatically expire.</param>
+    /// <param name="leaseTime">The duration used to acquire the lock.</param>
     /// <param name="timeProvider">The time provider for getting current time.</param>
-    /// <param name="releaseAction">The action to execute when the lock is released.</param>
+    /// <param name="releaseAction">The action to execute with the current expiry when the lock is released.</param>
+    /// <param name="extendAction">The action to execute when the lock lease is extended.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="id"/> is null or whitespace.</exception>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="releaseAction"/> is null.</exception>
-    public MongoLock(String id, DateTime validUntilUtc, TimeProvider timeProvider, Func<Task> releaseAction)
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="timeProvider"/>, <paramref name="releaseAction"/>,
+    /// or <paramref name="extendAction"/> is null.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="leaseTime"/> is shorter than one millisecond.</exception>
+    public MongoLock(String id,
+                     DateTime validUntilUtc,
+                     TimeSpan leaseTime,
+                     TimeProvider timeProvider,
+                     Func<DateTime, Task> releaseAction,
+                     Func<DateTime, TimeSpan, CancellationToken, Task<DateTime?>> extendAction)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(id);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(releaseAction);
+        ArgumentNullException.ThrowIfNull(extendAction);
+        ValidateLeaseTime(leaseTime, nameof(leaseTime));
 
         Id = id;
-        ValidUntilUtc = validUntilUtc;
+        _validUntilUtc = validUntilUtc;
+        _leaseTime = leaseTime;
         _timeProvider = timeProvider;
         _releaseAction = releaseAction;
+        _extendAction = extendAction;
     }
 
     /// <inheritdoc/>
     public String Id { get; }
 
     /// <inheritdoc/>
-    public Boolean IsValid => !_disposed && ValidUntilUtc > _timeProvider.GetUtcNow().UtcDateTime;
+    public Boolean IsValid
+    {
+        get
+        {
+            lock (_stateLock)
+                return !_disposed && !_lost && _validUntilUtc > _timeProvider.GetUtcNow().UtcDateTime;
+        }
+    }
 
     /// <inheritdoc/>
-    public DateTime ValidUntilUtc { get; }
+    public DateTime ValidUntilUtc
+    {
+        get
+        {
+            lock (_stateLock)
+                return _validUntilUtc;
+        }
+    }
+
+    private static void ValidateLeaseTime(TimeSpan leaseTime, String parameterName)
+    {
+        if (leaseTime < TimeSpan.FromMilliseconds(1))
+            throw new ArgumentOutOfRangeException(parameterName, leaseTime, "Lease time must be at least one millisecond.");
+    }
 
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        if (_disposed)
-            return;
-
-        _disposed = true;
+        // Waits for an in-flight extension so the release below uses the expiry that extension stored. The wait is
+        // unbounded by design: disposal is a cold path, and a bounded wait would race the extension it exists to exclude.
+        await _operationSemaphore.WaitAsync();
 
         try
         {
-            await _releaseAction();
+            DateTime validUntilUtc;
+
+            lock (_stateLock)
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+                validUntilUtc = _validUntilUtc;
+            }
+
+            try
+            {
+                await _releaseAction(validUntilUtc);
+            }
+            catch
+            {
+                // Suppress exceptions during dispose to prevent unhandled exceptions.
+                // Locks will eventually expire anyway.
+            }
         }
-        catch
+        finally
         {
-            // Suppress exceptions during dispose to prevent unhandled exceptions
-            // Locks will eventually expire anyway
+            _operationSemaphore.Release();
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<Boolean> TryExtendAsync(TimeSpan? leaseTime = null, CancellationToken cancellationToken = default)
+    {
+        var requestedLeaseTime = leaseTime ?? _leaseTime;
+        ValidateLeaseTime(requestedLeaseTime, nameof(leaseTime));
+
+        await _operationSemaphore.WaitAsync(cancellationToken);
+
+        try
+        {
+            DateTime validUntilUtc;
+
+            lock (_stateLock)
+            {
+                if (_disposed || _lost)
+                    return false;
+
+                validUntilUtc = _validUntilUtc;
+            }
+
+            var extendedUntilUtc = await _extendAction(validUntilUtc, requestedLeaseTime, cancellationToken);
+
+            lock (_stateLock)
+            {
+                if (extendedUntilUtc is null)
+                {
+                    _lost = true;
+                    return false;
+                }
+
+                _validUntilUtc = extendedUntilUtc.Value;
+                return true;
+            }
+        }
+        finally
+        {
+            _operationSemaphore.Release();
         }
     }
 }

--- a/src/Chaos.Mongo/MongoLockExtensions.cs
+++ b/src/Chaos.Mongo/MongoLockExtensions.cs
@@ -25,4 +25,27 @@ public static class MongoLockExtensions
 
         return mongoLock;
     }
+
+    /// <summary>
+    /// Extends the lock lease or throws when the lock is no longer held.
+    /// </summary>
+    /// <param name="mongoLock">The lock to extend.</param>
+    /// <param name="leaseTime">Optional lease duration. Defaults to the duration used to acquire the lock.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>The same lock instance after its lease has been extended.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="mongoLock"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="leaseTime"/> is shorter than one millisecond.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the lock lease cannot be extended.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken"/> is cancelled.</exception>
+    public static async Task<IMongoLock> ExtendAsync(this IMongoLock mongoLock,
+                                                     TimeSpan? leaseTime = null,
+                                                     CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(mongoLock);
+
+        if (!await mongoLock.TryExtendAsync(leaseTime, cancellationToken))
+            throw new InvalidOperationException($"MongoDB lock {mongoLock.Id} could not be extended because it is no longer held.");
+
+        return mongoLock;
+    }
 }

--- a/tests/Chaos.Mongo.Tests/Integration/MongoHelperLockIntegrationTests.cs
+++ b/tests/Chaos.Mongo.Tests/Integration/MongoHelperLockIntegrationTests.cs
@@ -4,6 +4,7 @@ namespace Chaos.Mongo.Tests.Integration;
 
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using MongoDB.Driver;
 using NUnit.Framework;
 using Testcontainers.MongoDb;
@@ -11,6 +12,89 @@ using Testcontainers.MongoDb;
 public class MongoHelperLockIntegrationTests
 {
     private MongoDbContainer _container;
+
+    [Test]
+    public async Task DisposeAsync_WhenSameHolderReacquiredExpiredLock_ShouldNotDeleteSuccessor()
+    {
+        // Arrange
+        var url = MongoUrl.Create(_container.GetConnectionString());
+        var uniqueDbName = $"LockTestDb_{Guid.NewGuid():N}";
+        var timeProvider = new FakeTimeProvider();
+        var mongoHelper = CreateMongoHelper(url, uniqueDbName, "shared-holder", timeProvider);
+        var lockCollection = mongoHelper.Database.GetCollection<MongoLockDocument>("_locks");
+        var staleLock = await mongoHelper.TryAcquireLockAsync("reacquired-lock", TimeSpan.FromMinutes(1));
+        staleLock.Should().NotBeNull();
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        var laterLock = await mongoHelper.TryAcquireLockAsync("reacquired-lock", TimeSpan.FromMinutes(5));
+        laterLock.Should().NotBeNull();
+        await using var successorLock = laterLock!;
+
+        // Act
+        await staleLock!.DisposeAsync();
+
+        // Assert
+        var lockDocument = await lockCollection.Find(x => x.Id == "reacquired-lock").SingleAsync();
+        lockDocument.Holder.Should().Be("shared-holder");
+        lockDocument.LeaseUntilUtc.Should().Be(successorLock.ValidUntilUtc);
+    }
+
+    [Test]
+    public async Task ExtensionAndAcquisition_AtExpiryWithSharedClock_AcquisitionShouldWin()
+    {
+        // Arrange
+        var url = MongoUrl.Create(_container.GetConnectionString());
+        var uniqueDbName = $"LockTestDb_{Guid.NewGuid():N}";
+        var timeProvider = new FakeTimeProvider();
+        var helper1 = CreateMongoHelper(url, uniqueDbName, "holder-1", timeProvider);
+        var helper2 = CreateMongoHelper(url, uniqueDbName, "holder-2", timeProvider);
+        var lockCollection = helper1.Database.GetCollection<MongoLockDocument>("_locks");
+        var firstLock = await helper1.TryAcquireLockAsync("at-expiry-race", TimeSpan.FromMinutes(10));
+        firstLock.Should().NotBeNull();
+        await using var originalLock = firstLock!;
+        timeProvider.Advance(TimeSpan.FromMinutes(10));
+
+        // Act
+        var extensionTask = originalLock.TryExtendAsync(TimeSpan.FromMinutes(20));
+        var acquisitionTask = helper2.TryAcquireLockAsync("at-expiry-race", TimeSpan.FromMinutes(5));
+        await Task.WhenAll(extensionTask, acquisitionTask);
+
+        // Assert
+        (await extensionTask).Should().BeFalse();
+        var acquiredLock = await acquisitionTask;
+        acquiredLock.Should().NotBeNull();
+        await using var successorLock = acquiredLock!;
+        var lockDocument = await lockCollection.Find(x => x.Id == "at-expiry-race").SingleAsync();
+        lockDocument.Holder.Should().Be("holder-2");
+        lockDocument.LeaseUntilUtc.Should().Be(successorLock.ValidUntilUtc);
+    }
+
+    [Test]
+    public async Task ExtensionAndAcquisition_BeforeExpiryWithSharedClock_ExtensionShouldWin()
+    {
+        // Arrange
+        var url = MongoUrl.Create(_container.GetConnectionString());
+        var uniqueDbName = $"LockTestDb_{Guid.NewGuid():N}";
+        var timeProvider = new FakeTimeProvider();
+        var helper1 = CreateMongoHelper(url, uniqueDbName, "holder-1", timeProvider);
+        var helper2 = CreateMongoHelper(url, uniqueDbName, "holder-2", timeProvider);
+        var lockCollection = helper1.Database.GetCollection<MongoLockDocument>("_locks");
+        var acquiredLock = await helper1.TryAcquireLockAsync("before-expiry-race", TimeSpan.FromMinutes(10));
+        acquiredLock.Should().NotBeNull();
+        await using var lockInstance = acquiredLock!;
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        // Act
+        var extensionTask = lockInstance.TryExtendAsync(TimeSpan.FromMinutes(20));
+        var acquisitionTask = helper2.TryAcquireLockAsync("before-expiry-race", TimeSpan.FromMinutes(5));
+        await Task.WhenAll(extensionTask, acquisitionTask);
+
+        // Assert
+        (await extensionTask).Should().BeTrue();
+        (await acquisitionTask).Should().BeNull();
+        var lockDocument = await lockCollection.Find(x => x.Id == "before-expiry-race").SingleAsync();
+        lockDocument.Holder.Should().Be("holder-1");
+        lockDocument.LeaseUntilUtc.Should().Be(lockInstance.ValidUntilUtc);
+    }
 
     [OneTimeSetUp]
     public async Task GetMongoDbContainer() => _container = await MongoDbTestContainer.StartContainerAsync();
@@ -33,10 +117,11 @@ public class MongoHelperLockIntegrationTests
         var mongoHelper = (MongoHelper)serviceProvider.GetRequiredService<IMongoHelper>();
         var lockCollection = mongoHelper.Database.GetCollection<MongoLockDocument>("_locks");
 
-        await mongoHelper.TryAcquireLockAsync("direct-release-lock");
+        var lockInstance = await mongoHelper.TryAcquireLockAsync("direct-release-lock");
+        lockInstance.Should().NotBeNull();
 
         // Act
-        await mongoHelper.ReleaseLockAsync("direct-release-lock", "direct-release-holder");
+        await mongoHelper.ReleaseLockAsync("direct-release-lock", "direct-release-holder", lockInstance!.ValidUntilUtc);
 
         // Assert
         var lockDoc = await lockCollection.Find(x => x.Id == "direct-release-lock").FirstOrDefaultAsync();
@@ -61,10 +146,11 @@ public class MongoHelperLockIntegrationTests
         var mongoHelper = (MongoHelper)serviceProvider.GetRequiredService<IMongoHelper>();
         var lockCollection = mongoHelper.Database.GetCollection<MongoLockDocument>("_locks");
 
-        await mongoHelper.TryAcquireLockAsync("protected-lock");
+        var lockInstance = await mongoHelper.TryAcquireLockAsync("protected-lock");
+        lockInstance.Should().NotBeNull();
 
         // Act - Try to release with wrong holder ID
-        await mongoHelper.ReleaseLockAsync("protected-lock", "wrong-holder");
+        await mongoHelper.ReleaseLockAsync("protected-lock", "wrong-holder", lockInstance!.ValidUntilUtc);
 
         // Assert - Lock should still exist
         var lockDoc = await lockCollection.Find(x => x.Id == "protected-lock").FirstOrDefaultAsync();
@@ -349,5 +435,154 @@ public class MongoHelperLockIntegrationTests
 
         // Assert
         await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Test]
+    public async Task TryAcquireLockAsync_WithSubMillisecondLease_ShouldThrowBeforeWritingDocument()
+    {
+        // Arrange
+        var url = MongoUrl.Create(_container.GetConnectionString());
+        var uniqueDbName = $"LockTestDb_{Guid.NewGuid():N}";
+        var mongoHelper = CreateMongoHelper(url, uniqueDbName, "test-holder", new FakeTimeProvider());
+        var lockCollection = mongoHelper.Database.GetCollection<MongoLockDocument>("_locks");
+
+        // Act
+        var act = async () => await mongoHelper.TryAcquireLockAsync("short-lease", TimeSpan.FromTicks(1));
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+        (await lockCollection.CountDocumentsAsync(FilterDefinition<MongoLockDocument>.Empty)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenAnotherHolderAcquiredExpiredLock_ShouldRefuseWithoutModifyingSuccessor()
+    {
+        // Arrange
+        var url = MongoUrl.Create(_container.GetConnectionString());
+        var uniqueDbName = $"LockTestDb_{Guid.NewGuid():N}";
+        var timeProvider = new FakeTimeProvider();
+        var helper1 = CreateMongoHelper(url, uniqueDbName, "holder-1", timeProvider);
+        var helper2 = CreateMongoHelper(url, uniqueDbName, "holder-2", timeProvider);
+        var lockCollection = helper1.Database.GetCollection<MongoLockDocument>("_locks");
+        var firstLock = await helper1.TryAcquireLockAsync("stolen-lock", TimeSpan.FromMinutes(1));
+        firstLock.Should().NotBeNull();
+        await using var originalLock = firstLock!;
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        var secondLock = await helper2.TryAcquireLockAsync("stolen-lock", TimeSpan.FromMinutes(5));
+        secondLock.Should().NotBeNull();
+        await using var successorLock = secondLock!;
+
+        // Act
+        var result = await originalLock.TryExtendAsync();
+
+        // Assert
+        result.Should().BeFalse();
+        originalLock.IsValid.Should().BeFalse();
+        var lockDocument = await lockCollection.Find(x => x.Id == "stolen-lock").SingleAsync();
+        lockDocument.Holder.Should().Be("holder-2");
+        lockDocument.LeaseUntilUtc.Should().Be(successorLock.ValidUntilUtc);
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenExpiredAndUnclaimed_ShouldRefuseWithoutModifyingDocument()
+    {
+        // Arrange
+        var url = MongoUrl.Create(_container.GetConnectionString());
+        var uniqueDbName = $"LockTestDb_{Guid.NewGuid():N}";
+        var timeProvider = new FakeTimeProvider();
+        var mongoHelper = CreateMongoHelper(url, uniqueDbName, "holder-1", timeProvider);
+        var lockCollection = mongoHelper.Database.GetCollection<MongoLockDocument>("_locks");
+        var acquiredLock = await mongoHelper.TryAcquireLockAsync("expired-unclaimed-lock", TimeSpan.FromMinutes(1));
+        acquiredLock.Should().NotBeNull();
+        await using var lockInstance = acquiredLock!;
+        var originalExpiry = lockInstance.ValidUntilUtc;
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+
+        // Act
+        var result = await lockInstance.TryExtendAsync();
+
+        // Assert
+        result.Should().BeFalse();
+        lockInstance.IsValid.Should().BeFalse();
+        lockInstance.ValidUntilUtc.Should().Be(originalExpiry);
+        var lockDocument = await lockCollection.Find(x => x.Id == "expired-unclaimed-lock").SingleAsync();
+        lockDocument.Holder.Should().Be("holder-1");
+        lockDocument.LeaseUntilUtc.Should().Be(originalExpiry);
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenSameHolderReacquiredExpiredLock_ShouldRefuseWithoutModifyingSuccessor()
+    {
+        // Arrange
+        var url = MongoUrl.Create(_container.GetConnectionString());
+        var uniqueDbName = $"LockTestDb_{Guid.NewGuid():N}";
+        var timeProvider = new FakeTimeProvider();
+        var mongoHelper = CreateMongoHelper(url, uniqueDbName, "shared-holder", timeProvider);
+        var lockCollection = mongoHelper.Database.GetCollection<MongoLockDocument>("_locks");
+        var acquiredStaleLock = await mongoHelper.TryAcquireLockAsync("stale-extension-lock", TimeSpan.FromMinutes(1));
+        acquiredStaleLock.Should().NotBeNull();
+        await using var staleLock = acquiredStaleLock!;
+        var staleExpiry = staleLock.ValidUntilUtc;
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        var acquiredSuccessorLock = await mongoHelper.TryAcquireLockAsync("stale-extension-lock", TimeSpan.FromMinutes(5));
+        acquiredSuccessorLock.Should().NotBeNull();
+        await using var successorLock = acquiredSuccessorLock!;
+        var successorExpiry = successorLock.ValidUntilUtc;
+
+        // Act
+        var result = await staleLock.TryExtendAsync(TimeSpan.FromMinutes(10));
+
+        // Assert
+        result.Should().BeFalse();
+        staleLock.IsValid.Should().BeFalse();
+        staleLock.ValidUntilUtc.Should().Be(staleExpiry);
+        var lockDocument = await lockCollection.Find(x => x.Id == "stale-extension-lock").SingleAsync();
+        lockDocument.Holder.Should().Be("shared-holder");
+        lockDocument.LeaseUntilUtc.Should().Be(successorExpiry);
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenSuccessful_ShouldUpdateLockAndStoredDocument()
+    {
+        // Arrange
+        var url = MongoUrl.Create(_container.GetConnectionString());
+        var uniqueDbName = $"LockTestDb_{Guid.NewGuid():N}";
+        var timeProvider = new FakeTimeProvider();
+        var mongoHelper = CreateMongoHelper(url, uniqueDbName, "holder-1", timeProvider);
+        var lockCollection = mongoHelper.Database.GetCollection<MongoLockDocument>("_locks");
+        var acquiredLock = await mongoHelper.TryAcquireLockAsync("extend-lock", TimeSpan.FromMinutes(5));
+        acquiredLock.Should().NotBeNull();
+        await using var lockInstance = acquiredLock!;
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        var expectedExpiry = timeProvider.GetUtcNow().AddMinutes(10).UtcDateTime;
+
+        // Act
+        var result = await lockInstance.TryExtendAsync(TimeSpan.FromMinutes(10));
+
+        // Assert
+        result.Should().BeTrue();
+        lockInstance.ValidUntilUtc.Should().Be(expectedExpiry);
+        var lockDocument = await lockCollection.Find(x => x.Id == "extend-lock").SingleAsync();
+        lockDocument.Holder.Should().Be("holder-1");
+        lockDocument.LeaseUntilUtc.Should().Be(expectedExpiry);
+    }
+
+    private static MongoHelper CreateMongoHelper(MongoUrl url,
+                                                 String databaseName,
+                                                 String holderId,
+                                                 TimeProvider timeProvider)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(timeProvider);
+
+        return (MongoHelper)services
+                            .AddMongo(url, configure: options =>
+                            {
+                                options.DefaultDatabase = databaseName;
+                                options.HolderId = holderId;
+                            })
+                            .Services
+                            .BuildServiceProvider()
+                            .GetRequiredService<IMongoHelper>();
     }
 }

--- a/tests/Chaos.Mongo.Tests/MongoLockExtensionsTests.cs
+++ b/tests/Chaos.Mongo.Tests/MongoLockExtensionsTests.cs
@@ -4,16 +4,19 @@ namespace Chaos.Mongo.Tests;
 
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
+using MongoDB.Driver;
 using NUnit.Framework;
 
 public class MongoLockExtensionsTests
 {
+    private static readonly TimeSpan _defaultLeaseTime = TimeSpan.FromMinutes(5);
+
     [Test]
     public async Task EnsureValid_AfterDisposal_ShouldThrowInvalidOperationException()
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("disposed-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("disposed-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider);
         await mongoLock.DisposeAsync();
 
         // Act
@@ -29,7 +32,7 @@ public class MongoLockExtensionsTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("transition-lock", timeProvider.GetUtcNow().AddMilliseconds(100).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("transition-lock", timeProvider.GetUtcNow().AddMilliseconds(100).UtcDateTime, timeProvider);
 
         // Act & Assert - Valid before expiration
         mongoLock.EnsureValid().Should().BeSameAs(mongoLock);
@@ -47,8 +50,8 @@ public class MongoLockExtensionsTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var validLock = new MongoLock("valid-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, () => Task.CompletedTask);
-        var expiredLock = new MongoLock("expired-lock", timeProvider.GetUtcNow().AddMilliseconds(-100).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var validLock = CreateMongoLock("valid-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider);
+        var expiredLock = CreateMongoLock("expired-lock", timeProvider.GetUtcNow().AddMilliseconds(-100).UtcDateTime, timeProvider);
 
         // Act & Assert
         validLock.EnsureValid().Should().BeSameAs(validLock);
@@ -61,7 +64,7 @@ public class MongoLockExtensionsTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("expired-lock", timeProvider.GetUtcNow().AddMilliseconds(-100).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("expired-lock", timeProvider.GetUtcNow().AddMilliseconds(-100).UtcDateTime, timeProvider);
 
         // Act
         var act = () => mongoLock.EnsureValid();
@@ -76,7 +79,7 @@ public class MongoLockExtensionsTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("fluent-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("fluent-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider);
 
         // Act
         var result = mongoLock.EnsureValid().EnsureValid().EnsureValid();
@@ -104,12 +107,115 @@ public class MongoLockExtensionsTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider);
 
         // Act
         var result = mongoLock.EnsureValid();
 
         // Assert
         result.Should().BeSameAs(mongoLock);
+    }
+
+    [Test]
+    public async Task ExtendAsync_WhenCancelled_ShouldPropagateCancellation()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        // Act
+        var act = async () => await mongoLock.ExtendAsync(cancellationToken: cancellationTokenSource.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        mongoLock.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ExtendAsync_WhenExtensionIsRefused_ShouldThrowInvalidOperationException()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var mongoLock = CreateMongoLock(
+            "refused-lock",
+            timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime,
+            timeProvider,
+            (_, _, _) => Task.FromResult<DateTime?>(null));
+
+        // Act
+        var act = async () => await mongoLock.ExtendAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+                 .WithMessage("*refused-lock*");
+    }
+
+    [Test]
+    public async Task ExtendAsync_WhenExtensionSucceeds_ShouldReturnSameLock()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var extendedExpiry = timeProvider.GetUtcNow().AddMinutes(10).UtcDateTime;
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime,
+            timeProvider,
+            (_, _, _) => Task.FromResult<DateTime?>(extendedExpiry));
+
+        // Act
+        var result = await mongoLock.ExtendAsync();
+
+        // Assert
+        result.Should().BeSameAs(mongoLock);
+        result.ValidUntilUtc.Should().Be(extendedExpiry);
+    }
+
+    [Test]
+    public async Task ExtendAsync_WhenMongoDbOperationThrows_ShouldPropagateException()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var expectedException = new MongoException("Extension failed");
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime,
+            timeProvider,
+            (_, _, _) => Task.FromException<DateTime?>(expectedException));
+
+        // Act
+        var act = async () => await mongoLock.ExtendAsync();
+
+        // Assert
+        var exception = await act.Should().ThrowAsync<MongoException>();
+        exception.Which.Should().BeSameAs(expectedException);
+    }
+
+    [Test]
+    public async Task ExtendAsync_WithNullLock_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        IMongoLock? mongoLock = null;
+
+        // Act
+        var act = async () => await mongoLock!.ExtendAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private static MongoLock CreateMongoLock(
+        String id,
+        DateTime validUntilUtc,
+        TimeProvider timeProvider,
+        Func<DateTime, TimeSpan, CancellationToken, Task<DateTime?>>? extendAction = null)
+    {
+        return new(id,
+                   validUntilUtc,
+                   _defaultLeaseTime,
+                   timeProvider,
+                   _ => Task.CompletedTask,
+                   extendAction ?? ((_, duration, _) => Task.FromResult<DateTime?>(timeProvider.GetUtcNow().Add(duration).UtcDateTime)));
     }
 }

--- a/tests/Chaos.Mongo.Tests/MongoLockTests.cs
+++ b/tests/Chaos.Mongo.Tests/MongoLockTests.cs
@@ -4,23 +4,68 @@ namespace Chaos.Mongo.Tests;
 
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
+using MongoDB.Driver;
 using NUnit.Framework;
 
 public class MongoLockTests
 {
+    private static readonly TimeSpan _defaultLeaseTime = TimeSpan.FromMinutes(5);
+
     [Test]
     public void Constructor_WithEmptyId_ShouldThrowArgumentException()
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
         var validUntil = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
-        var releaseAction = () => Task.CompletedTask;
+        Func<DateTime, Task> releaseAction = _ => Task.CompletedTask;
+        Func<DateTime, TimeSpan, CancellationToken, Task<DateTime?>> extendAction = (_, _, _) => Task.FromResult<DateTime?>(validUntil);
 
         // Act
-        var act = () => new MongoLock(String.Empty, validUntil, timeProvider, releaseAction);
+        var act = () => new MongoLock(String.Empty, validUntil, _defaultLeaseTime, timeProvider, releaseAction, extendAction);
 
         // Assert
         act.Should().Throw<ArgumentException>();
+    }
+
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(0.5)]
+    public void Constructor_WithLeaseTimeShorterThanOneMillisecond_ShouldThrowArgumentOutOfRangeException(Double milliseconds)
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var validUntil = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
+        var leaseTime = TimeSpan.FromMilliseconds(milliseconds);
+
+        // Act
+        var act = () => new MongoLock("test-lock",
+                                      validUntil,
+                                      leaseTime,
+                                      timeProvider,
+                                      _ => Task.CompletedTask,
+                                      (_, _, _) => Task.FromResult<DateTime?>(validUntil));
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void Constructor_WithNullExtendAction_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var validUntil = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
+
+        // Act
+        var act = () => new MongoLock("test-lock",
+                                      validUntil,
+                                      _defaultLeaseTime,
+                                      timeProvider,
+                                      _ => Task.CompletedTask,
+                                      null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
     }
 
     [Test]
@@ -29,10 +74,11 @@ public class MongoLockTests
         // Arrange
         var timeProvider = new FakeTimeProvider();
         var validUntil = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
-        var releaseAction = () => Task.CompletedTask;
+        Func<DateTime, Task> releaseAction = _ => Task.CompletedTask;
+        Func<DateTime, TimeSpan, CancellationToken, Task<DateTime?>> extendAction = (_, _, _) => Task.FromResult<DateTime?>(validUntil);
 
         // Act
-        var act = () => new MongoLock(null!, validUntil, timeProvider, releaseAction);
+        var act = () => new MongoLock(null!, validUntil, _defaultLeaseTime, timeProvider, releaseAction, extendAction);
 
         // Assert
         act.Should().Throw<ArgumentException>();
@@ -47,7 +93,12 @@ public class MongoLockTests
         var validUntil = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
 
         // Act
-        var act = () => new MongoLock(lockId, validUntil, timeProvider, null!);
+        var act = () => new MongoLock(lockId,
+                                      validUntil,
+                                      _defaultLeaseTime,
+                                      timeProvider,
+                                      null!,
+                                      (_, _, _) => Task.FromResult<DateTime?>(validUntil));
 
         // Assert
         act.Should().Throw<ArgumentNullException>();
@@ -60,10 +111,10 @@ public class MongoLockTests
         var timeProvider = new FakeTimeProvider();
         var lockId = "test-lock";
         var validUntil = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
-        var releaseAction = () => Task.CompletedTask;
+        Func<DateTime, Task> releaseAction = _ => Task.CompletedTask;
 
         // Act
-        var mongoLock = new MongoLock(lockId, validUntil, timeProvider, releaseAction);
+        var mongoLock = CreateMongoLock(lockId, validUntil, timeProvider, releaseAction);
 
         // Assert
         mongoLock.Id.Should().Be(lockId);
@@ -76,10 +127,11 @@ public class MongoLockTests
         // Arrange
         var timeProvider = new FakeTimeProvider();
         var validUntil = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
-        var releaseAction = () => Task.CompletedTask;
+        Func<DateTime, Task> releaseAction = _ => Task.CompletedTask;
+        Func<DateTime, TimeSpan, CancellationToken, Task<DateTime?>> extendAction = (_, _, _) => Task.FromResult<DateTime?>(validUntil);
 
         // Act
-        var act = () => new MongoLock("   ", validUntil, timeProvider, releaseAction);
+        var act = () => new MongoLock("   ", validUntil, _defaultLeaseTime, timeProvider, releaseAction, extendAction);
 
         // Assert
         act.Should().Throw<ArgumentException>();
@@ -91,12 +143,12 @@ public class MongoLockTests
         // Arrange
         var timeProvider = new FakeTimeProvider();
         var releaseInvoked = false;
-        var releaseAction = () =>
+        Func<DateTime, Task> releaseAction = _ =>
         {
             releaseInvoked = true;
             return Task.CompletedTask;
         };
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, releaseAction);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, releaseAction);
 
         // Act
         await mongoLock.DisposeAsync();
@@ -111,12 +163,12 @@ public class MongoLockTests
         // Arrange
         var timeProvider = new FakeTimeProvider();
         var releaseCount = 0;
-        var releaseAction = () =>
+        Func<DateTime, Task> releaseAction = _ =>
         {
             releaseCount++;
             return Task.CompletedTask;
         };
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, releaseAction);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, releaseAction);
 
         // Act
         await mongoLock.DisposeAsync();
@@ -128,12 +180,52 @@ public class MongoLockTests
     }
 
     [Test]
+    public async Task DisposeAsync_WhenExtensionIsInFlight_ShouldReleaseExtendedExpiryWithoutResurrectingLock()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var originalExpiry = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
+        var extendedExpiry = timeProvider.GetUtcNow().AddMinutes(10).UtcDateTime;
+        var extensionStarted = new TaskCompletionSource<Boolean>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completeExtension = new TaskCompletionSource<DateTime?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        DateTime? releasedExpiry = null;
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            originalExpiry,
+            timeProvider,
+            releaseAction: validUntilUtc =>
+            {
+                releasedExpiry = validUntilUtc;
+                return Task.CompletedTask;
+            },
+            extendAction: async (_, _, _) =>
+            {
+                extensionStarted.SetResult(true);
+                return await completeExtension.Task;
+            });
+
+        var extensionTask = mongoLock.TryExtendAsync();
+        await extensionStarted.Task;
+
+        // Act
+        var disposalTask = mongoLock.DisposeAsync().AsTask();
+        completeExtension.SetResult(extendedExpiry);
+
+        // Assert
+        (await extensionTask).Should().BeTrue();
+        await disposalTask;
+        releasedExpiry.Should().Be(extendedExpiry);
+        mongoLock.ValidUntilUtc.Should().Be(extendedExpiry);
+        mongoLock.IsValid.Should().BeFalse();
+    }
+
+    [Test]
     public async Task DisposeAsync_WhenReleaseActionThrows_ShouldSuppressException()
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        Func<Task> releaseAction = () => throw new InvalidOperationException("Release failed");
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, releaseAction);
+        Func<DateTime, Task> releaseAction = _ => throw new InvalidOperationException("Release failed");
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, releaseAction);
 
         // Act
         var act = async () => await mongoLock.DisposeAsync();
@@ -148,12 +240,12 @@ public class MongoLockTests
         // Arrange
         var timeProvider = new FakeTimeProvider();
         var releaseCompleted = false;
-        var releaseAction = () =>
+        Func<DateTime, Task> releaseAction = _ =>
         {
             releaseCompleted = true;
             return Task.CompletedTask;
         };
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, releaseAction);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, releaseAction);
 
         // Act
         await mongoLock.DisposeAsync();
@@ -167,7 +259,7 @@ public class MongoLockTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider);
         mongoLock.IsValid.Should().BeTrue();
 
         // Act
@@ -182,7 +274,7 @@ public class MongoLockTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider);
 
         // Act
         await mongoLock.DisposeAsync();
@@ -198,7 +290,7 @@ public class MongoLockTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMilliseconds(100).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMilliseconds(100).UtcDateTime, timeProvider);
         mongoLock.IsValid.Should().BeTrue();
 
         // Act - Wait for expiration
@@ -213,7 +305,7 @@ public class MongoLockTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMilliseconds(-100).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMilliseconds(-100).UtcDateTime, timeProvider);
 
         // Act & Assert
         mongoLock.IsValid.Should().BeFalse();
@@ -224,9 +316,232 @@ public class MongoLockTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider();
-        var mongoLock = new MongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider, () => Task.CompletedTask);
+        var mongoLock = CreateMongoLock("test-lock", timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime, timeProvider);
 
         // Act & Assert
         mongoLock.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TryExtendAsync_AfterSuccessfulExtension_ShouldPassUpdatedExpiryToDelegate()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var originalExpiry = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
+        var firstExtendedExpiry = timeProvider.GetUtcNow().AddMinutes(10).UtcDateTime;
+        var secondExtendedExpiry = timeProvider.GetUtcNow().AddMinutes(15).UtcDateTime;
+        var expectedExpiries = new List<DateTime>();
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            originalExpiry,
+            timeProvider,
+            extendAction: (validUntilUtc, _, _) =>
+            {
+                expectedExpiries.Add(validUntilUtc);
+                return Task.FromResult<DateTime?>(expectedExpiries.Count == 1 ? firstExtendedExpiry : secondExtendedExpiry);
+            });
+
+        // Act
+        var firstResult = await mongoLock.TryExtendAsync();
+        var secondResult = await mongoLock.TryExtendAsync();
+
+        // Assert
+        firstResult.Should().BeTrue();
+        secondResult.Should().BeTrue();
+        expectedExpiries.Should().Equal(originalExpiry, firstExtendedExpiry);
+        mongoLock.ValidUntilUtc.Should().Be(secondExtendedExpiry);
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenCancelledBeforeInvocation_ShouldLeaveStateUnchanged()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var originalExpiry = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
+        var extendInvoked = false;
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            originalExpiry,
+            timeProvider,
+            extendAction: (_, _, _) =>
+            {
+                extendInvoked = true;
+                return Task.FromResult<DateTime?>(originalExpiry);
+            });
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        // Act
+        var act = async () => await mongoLock.TryExtendAsync(cancellationToken: cancellationTokenSource.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        extendInvoked.Should().BeFalse();
+        mongoLock.ValidUntilUtc.Should().Be(originalExpiry);
+        mongoLock.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenDelegateRefuses_ShouldMarkLockAsLost()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var originalExpiry = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            originalExpiry,
+            timeProvider,
+            extendAction: (_, _, _) => Task.FromResult<DateTime?>(null));
+
+        // Act
+        var result = await mongoLock.TryExtendAsync();
+
+        // Assert
+        result.Should().BeFalse();
+        mongoLock.ValidUntilUtc.Should().Be(originalExpiry);
+        mongoLock.IsValid.Should().BeFalse();
+        var ensureValid = () => mongoLock.EnsureValid();
+        ensureValid.Should().Throw<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenDisposed_ShouldRefuseWithoutInvokingDelegate()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var extendInvoked = false;
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime,
+            timeProvider,
+            extendAction: (_, _, _) =>
+            {
+                extendInvoked = true;
+                return Task.FromResult<DateTime?>(timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime);
+            });
+        await mongoLock.DisposeAsync();
+
+        // Act
+        var result = await mongoLock.TryExtendAsync();
+
+        // Assert
+        result.Should().BeFalse();
+        extendInvoked.Should().BeFalse();
+        mongoLock.IsValid.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenLeaseExpired_ShouldMarkLockAsLostAfterDelegateRefuses()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            timeProvider.GetUtcNow().AddMilliseconds(-1).UtcDateTime,
+            timeProvider,
+            extendAction: (_, _, _) => Task.FromResult<DateTime?>(null));
+
+        // Act
+        var result = await mongoLock.TryExtendAsync();
+
+        // Assert
+        result.Should().BeFalse();
+        mongoLock.IsValid.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WhenMongoDbOperationThrows_ShouldLeaveStateUnchanged()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var originalExpiry = timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime;
+        var expectedException = new MongoException("Extension failed");
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            originalExpiry,
+            timeProvider,
+            extendAction: (_, _, _) => Task.FromException<DateTime?>(expectedException));
+
+        // Act
+        var act = async () => await mongoLock.TryExtendAsync();
+
+        // Assert
+        var exception = await act.Should().ThrowAsync<MongoException>();
+        exception.Which.Should().BeSameAs(expectedException);
+        mongoLock.ValidUntilUtc.Should().Be(originalExpiry);
+        mongoLock.IsValid.Should().BeTrue();
+    }
+
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(0.5)]
+    public async Task TryExtendAsync_WithLeaseTimeShorterThanOneMillisecond_ShouldThrowBeforeInvokingDelegate(Double milliseconds)
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var extendInvoked = false;
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime,
+            timeProvider,
+            extendAction: (_, _, _) =>
+            {
+                extendInvoked = true;
+                return Task.FromResult<DateTime?>(timeProvider.GetUtcNow().AddMinutes(5).UtcDateTime);
+            });
+
+        // Act
+        var act = async () => await mongoLock.TryExtendAsync(TimeSpan.FromMilliseconds(milliseconds));
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+        extendInvoked.Should().BeFalse();
+        mongoLock.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task TryExtendAsync_WithoutLeaseTime_ShouldUseOriginalLeaseAndUpdateExpiry()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var originalExpiry = timeProvider.GetUtcNow().AddMinutes(1).UtcDateTime;
+        var extendedExpiry = timeProvider.GetUtcNow().Add(_defaultLeaseTime).UtcDateTime;
+        DateTime? expectedExpiry = null;
+        TimeSpan? requestedLeaseTime = null;
+        var mongoLock = CreateMongoLock(
+            "test-lock",
+            originalExpiry,
+            timeProvider,
+            extendAction: (validUntilUtc, leaseTime, _) =>
+            {
+                expectedExpiry = validUntilUtc;
+                requestedLeaseTime = leaseTime;
+                return Task.FromResult<DateTime?>(extendedExpiry);
+            });
+
+        // Act
+        var result = await mongoLock.TryExtendAsync();
+
+        // Assert
+        result.Should().BeTrue();
+        expectedExpiry.Should().Be(originalExpiry);
+        requestedLeaseTime.Should().Be(_defaultLeaseTime);
+        mongoLock.ValidUntilUtc.Should().Be(extendedExpiry);
+        mongoLock.IsValid.Should().BeTrue();
+    }
+
+    private static MongoLock CreateMongoLock(String id,
+                                             DateTime validUntilUtc,
+                                             TimeProvider timeProvider,
+                                             Func<DateTime, Task>? releaseAction = null,
+                                             Func<DateTime, TimeSpan, CancellationToken, Task<DateTime?>>? extendAction = null,
+                                             TimeSpan? leaseTime = null)
+    {
+        return new(id,
+                   validUntilUtc,
+                   leaseTime ?? _defaultLeaseTime,
+                   timeProvider,
+                   releaseAction ?? (_ => Task.CompletedTask),
+                   extendAction ?? ((_, duration, _) => Task.FromResult<DateTime?>(timeProvider.GetUtcNow().Add(duration).UtcDateTime)));
     }
 }


### PR DESCRIPTION
## Summary
Adds explicit lease renewal for held MongoDB distributed locks while preserving fail-closed ownership semantics. Renewal and release are fenced by stored expiry so stale instances cannot mutate later acquisitions.

## Changes
- Add TryExtendAsync and fluent ExtendAsync APIs with original-lease defaults and millisecond validation.
- Serialize renewal against disposal and fence MongoDB renewal and release operations by holder and stored expiry.
- Document renewal failure and clock-skew semantics, with deterministic unit and real-MongoDB concurrency coverage.

Closes #110